### PR TITLE
Work around dependency issues for Ubuntu 24.04

### DIFF
--- a/mesa-build.sh
+++ b/mesa-build.sh
@@ -178,6 +178,9 @@ install_spirv_deps() {
 
 	# # Handle SPIR-V to LLVM translator
 	case "$1" in
+		*"noble"*)
+		schroot -c $1 -- sh -c "sudo apt -y install libllvmspirvlib-19-dev"
+		;
 		*"plucky"*)
 		schroot -c $1 -- sh -c "sudo apt -y install libllvmspirvlib-20-dev"
 		;;


### PR DESCRIPTION
`apt build-deps -y mesa` is installing a version of `libllvmspirvlib-dev` that Mesa rejects.
This commit works around the issue by manually installing the correct version of the package when building in the noble chroot.